### PR TITLE
Remove the duplicate `MultiDiGraph.succ`

### DIFF
--- a/doc/reference/classes/multidigraph.rst
+++ b/doc/reference/classes/multidigraph.rst
@@ -56,7 +56,7 @@ Reporting nodes edges and neighbors
    MultiDiGraph.successors
    MultiDiGraph.succ
    MultiDiGraph.predecessors
-   MultiDiGraph.succ
+   MultiDiGraph.pred
    MultiDiGraph.adjacency
    MultiDiGraph.nbunch_iter
 


### PR DESCRIPTION
The `MultiDiGraph.succ` appears twice in the documentation, the second one should be `MultiDiGraph.pred`.

See https://networkx.org/documentation/stable/reference/classes/multidigraph.html.

<!--
Please run black to format your code.
See https://networkx.org/documentation/latest/developer/contribute.html for details.
-->
